### PR TITLE
 Add the ability to load image externally and asynchrously when the user click on gallery or nagiate between images

### DIFF
--- a/examples/angular-cli/src/app/app.component.html
+++ b/examples/angular-cli/src/app/app.component.html
@@ -434,6 +434,13 @@
                     [currentImageConfig]="{invertSwipe: true}"></ks-modal-gallery>
 </section>
 
+<section>
+  <h3>D4 - (id=55) - Other demo - Download modal image from outside (if needed) when showing in the modal gallery</h3>
+  <br>
+  <ks-modal-gallery [id]="55" [modalImages]="images"
+                    [onLoadCurrentImage]="onLoadCurrentImage"></ks-modal-gallery>
+</section>
+
 <br><br>
 <h4>This library and this example are created by <a href="https://github.com/Ks89">Stefano Cappa (@Ks89)</a></h4>
 

--- a/examples/angular-cli/src/app/app.component.ts
+++ b/examples/angular-cli/src/app/app.component.ts
@@ -660,4 +660,23 @@ export class AppComponent {
   private getCurrentIndexCustomLayout(image: Image, images: Image[]): number {
     return image ? images.indexOf(image) : -1;
   }
+
+  onLoadCurrentImage(currentImageId: string): Promise<string> {
+    if (currentImageId) {
+      //make an eternal call (to a server witch contains full definition image equivalent as base64 string)
+      //wait for the response and send it back to the component
+
+      // return this.myclientApi.getPictureFullScreenById(currentImageId).toPromise().then(
+      //   data => {
+      //     return data.fullscreen;
+      //   },
+      //   error => {
+      //     return undefined;
+      //   }
+      // )
+    } else {
+      return undefined;
+    }
+    
+  }
 }

--- a/libs/angular-modal-gallery/src/components/current-image/current-image.component.ts
+++ b/libs/angular-modal-gallery/src/components/current-image/current-image.component.ts
@@ -39,6 +39,8 @@ import { SlideConfig } from '../../model/slide-config.interface';
 import { NEXT, PREV } from '../../utils/user-input.util';
 import { getIndex } from '../../utils/image.util';
 import { CurrentImageConfig } from '../../model/current-image-config.interface';
+import { SafeResourceUrl } from '@angular/platform-browser';
+
 
 /**
  * Interface to describe the Load Event, used to
@@ -47,7 +49,7 @@ import { CurrentImageConfig } from '../../model/current-image-config.interface';
 export interface ImageLoadEvent {
   status: boolean;
   index: number;
-  id: number;
+  id: number|string;
 }
 
 /**
@@ -60,6 +62,15 @@ export interface ImageLoadEvent {
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CurrentImageComponent extends AccessibleComponent implements OnInit, OnChanges {
+
+
+  /**
+   * Allow user to load the modal picture when he clic on the gallery, in asynchronous way
+   *
+   * */
+  @Input()
+  onLoadCurrentImage: (value: number | string) => Promise<string | SafeResourceUrl>;
+
   /**
    * Object of type `InternalLibImage` that represent the visible image.
    */
@@ -156,6 +167,7 @@ export class CurrentImageComponent extends AccessibleComponent implements OnInit
     UP: 'swipeup',
     DOWN: 'swipedown'
   };
+   
 
   /**
    * Method ´ngOnInit´ to build `configCurrentImage` applying default values.
@@ -390,14 +402,31 @@ export class CurrentImageComponent extends AccessibleComponent implements OnInit
    * @param Event event that triggered the load
    */
   onImageLoad(event: Event) {
+
+    //if onLoadCurrentImage is defined, try to download the "full def" img externaly and asynchronously
+    if (this.currentImage.id && !this.currentImage.previouslyLoaded && this.onLoadCurrentImage) {   
+      this.onLoadCurrentImage(this.currentImage.id).then((newbase64str: string | SafeResourceUrl) => {
+        this.currentImage.modal.img = newbase64str;
+        this.currentImage.previouslyLoaded = true;
+        this.emitLoadEvent();
+      }, error => {
+        //if there is any error, deal with the regular way.
+        this.emitLoadEvent();
+      });
+      
+    } else {
+      this.emitLoadEvent();
+    }
+
+  }
+
+  private emitLoadEvent() {
     const loadImageData: ImageLoadEvent = {
       status: true,
       index: getIndex(this.currentImage, this.images),
       id: this.currentImage.id
     };
-
     this.loadImage.emit(loadImageData);
-
     this.loading = false;
   }
 

--- a/libs/angular-modal-gallery/src/components/modal-gallery/modal-gallery.component.ts
+++ b/libs/angular-modal-gallery/src/components/modal-gallery/modal-gallery.component.ts
@@ -48,7 +48,7 @@ import { PreviewConfig } from '../../model/preview-config.interface';
 import { SlideConfig } from '../../model/slide-config.interface';
 import { AccessibilityConfig } from '../../model/accessibility.interface';
 import { KeyboardService } from '../../services/keyboard.service';
-import { GalleryService, InternalGalleryPayload } from '../../services/gallery.service';
+import { GalleryService, InternalGalleryPayload, InternalGalleryRefresh } from '../../services/gallery.service';
 import { DotsConfig } from '../../model/dots-config.interface';
 import { CurrentImageComponent, ImageLoadEvent } from '../current-image/current-image.component';
 import { InternalLibImage } from '../../model/image-internal.class';
@@ -73,7 +73,7 @@ export class ModalGalleryComponent implements OnInit, OnDestroy, OnChanges {
    * the service to call modal gallery without open it manually.
    * Right now is optional, but in upcoming major releases will be mandatory!!!
    */
-  @Input() id: number;
+  @Input() id: number|string;
   /**
    * Array of `Image` that represent the model of this library with all images, thumbs and so on.
    */
@@ -177,6 +177,7 @@ export class ModalGalleryComponent implements OnInit, OnDestroy, OnChanges {
 
   private galleryServiceNavigateSubscription: Subscription;
   private galleryServiceCloseSubscription: Subscription;
+  private galleryServiceRefreshSubscription:Subscription;
 
   /**
    * Constructor with the injection of ´KeyboardService´ and an object to support Server-Side Rendering.
@@ -226,6 +227,30 @@ export class ModalGalleryComponent implements OnInit, OnDestroy, OnChanges {
       }
       this.closeGallery(Action.NORMAL, true);
     });
+
+    this.galleryServiceRefreshSubscription = this.galleryService.refresh.subscribe((payload:InternalGalleryRefresh)=>{
+      if (!payload){
+        return;
+      }
+      // if galleryId is not valid OR galleryId is related to another instance and not this one
+      if (payload.galleryId === undefined || payload.galleryId < 0 || payload.galleryId !== this.id) {
+        return;
+      }
+      // if image index is not valid
+      if (payload.imageIndex < 0 || payload.imageIndex > this.images.length) {
+        return;
+      }
+      
+      
+      this.modalImages = payload.images;
+      this.initImages();
+     
+      this.onChangeCurrentImage(new ImageModalEvent(Action.NORMAL, payload.imageIndex))
+    
+      
+
+
+    })
   }
 
   /**
@@ -577,6 +602,9 @@ export class ModalGalleryComponent implements OnInit, OnDestroy, OnChanges {
     }
     if (this.galleryServiceCloseSubscription) {
       this.galleryServiceCloseSubscription.unsubscribe();
+    }
+    if (this.galleryServiceRefreshSubscription){
+      this.galleryServiceRefreshSubscription.unsubscribe();
     }
   }
 

--- a/libs/angular-modal-gallery/src/components/modal-gallery/modal-gallery.component.ts
+++ b/libs/angular-modal-gallery/src/components/modal-gallery/modal-gallery.component.ts
@@ -48,7 +48,7 @@ import { PreviewConfig } from '../../model/preview-config.interface';
 import { SlideConfig } from '../../model/slide-config.interface';
 import { AccessibilityConfig } from '../../model/accessibility.interface';
 import { KeyboardService } from '../../services/keyboard.service';
-import { GalleryService, InternalGalleryPayload, InternalGalleryRefresh } from '../../services/gallery.service';
+import { GalleryService, InternalGalleryPayload } from '../../services/gallery.service';
 import { DotsConfig } from '../../model/dots-config.interface';
 import { CurrentImageComponent, ImageLoadEvent } from '../current-image/current-image.component';
 import { InternalLibImage } from '../../model/image-internal.class';

--- a/libs/angular-modal-gallery/src/components/modal-gallery/modal-gallery.component.ts
+++ b/libs/angular-modal-gallery/src/components/modal-gallery/modal-gallery.component.ts
@@ -68,12 +68,19 @@ import { CurrentImageConfig } from '../../model/current-image-config.interface';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ModalGalleryComponent implements OnInit, OnDestroy, OnChanges {
+ /**
+   * Allow user to load the modal picture when he clic on the gallery, in asynchronous way
+   *
+   * */
+  @Input()
+  onLoadCurrentImage: (value: number | string) => Promise<string>;
+
   /**
    * Unique id (>=0) of the current instance of this library. This is useful when you are using
    * the service to call modal gallery without open it manually.
    * Right now is optional, but in upcoming major releases will be mandatory!!!
    */
-  @Input() id: number|string;
+  @Input() id: number | string;
   /**
    * Array of `Image` that represent the model of this library with all images, thumbs and so on.
    */
@@ -177,7 +184,7 @@ export class ModalGalleryComponent implements OnInit, OnDestroy, OnChanges {
 
   private galleryServiceNavigateSubscription: Subscription;
   private galleryServiceCloseSubscription: Subscription;
-  private galleryServiceRefreshSubscription:Subscription;
+  
 
   /**
    * Constructor with the injection of ´KeyboardService´ and an object to support Server-Side Rendering.
@@ -187,7 +194,7 @@ export class ModalGalleryComponent implements OnInit, OnDestroy, OnChanges {
     private galleryService: GalleryService,
     @Inject(PLATFORM_ID) private platformId: Object,
     private changeDetectorRef: ChangeDetectorRef
-  ) {}
+  ) { }
 
   /**
    * Method ´ngOnInit´ to init images calling `initImages()`.
@@ -199,7 +206,7 @@ export class ModalGalleryComponent implements OnInit, OnDestroy, OnChanges {
     if ((!this.id && this.id !== 0) || this.id < 0) {
       throw new Error(
         `'[id]="a number >= 0"' is a mandatory input from 6.0.0 in angular-modal-gallery.` +
-          `If you are using multiple instances of this library, please be sure to use different ids`
+        `If you are using multiple instances of this library, please be sure to use different ids`
       );
     }
 
@@ -226,31 +233,7 @@ export class ModalGalleryComponent implements OnInit, OnDestroy, OnChanges {
         return;
       }
       this.closeGallery(Action.NORMAL, true);
-    });
-
-    this.galleryServiceRefreshSubscription = this.galleryService.refresh.subscribe((payload:InternalGalleryRefresh)=>{
-      if (!payload){
-        return;
-      }
-      // if galleryId is not valid OR galleryId is related to another instance and not this one
-      if (payload.galleryId === undefined || payload.galleryId < 0 || payload.galleryId !== this.id) {
-        return;
-      }
-      // if image index is not valid
-      if (payload.imageIndex < 0 || payload.imageIndex > this.images.length) {
-        return;
-      }
-      
-      
-      this.modalImages = payload.images;
-      this.initImages();
-     
-      this.onChangeCurrentImage(new ImageModalEvent(Action.NORMAL, payload.imageIndex))
-    
-      
-
-
-    })
+    });   
   }
 
   /**
@@ -602,10 +585,7 @@ export class ModalGalleryComponent implements OnInit, OnDestroy, OnChanges {
     }
     if (this.galleryServiceCloseSubscription) {
       this.galleryServiceCloseSubscription.unsubscribe();
-    }
-    if (this.galleryServiceRefreshSubscription){
-      this.galleryServiceRefreshSubscription.unsubscribe();
-    }
+    }   
   }
 
   /**

--- a/libs/angular-modal-gallery/src/components/modal-gallery/modal-gallery.html
+++ b/libs/angular-modal-gallery/src/components/modal-gallery/modal-gallery.html
@@ -34,7 +34,8 @@
                         [currentImageConfig]="currentImageConfig"
                         (loadImage)="onImageLoad($event)"
                         (changeImage)="onChangeCurrentImage($event)"
-                        (close)="onCloseGallery($event)"></ks-current-image>
+                        (close)="onCloseGallery($event)"
+                        [onLoadCurrentImage]="onLoadCurrentImage"></ks-current-image>
 
       <div>
         <ks-dots [images]="images"

--- a/libs/angular-modal-gallery/src/model/image-internal.class.ts
+++ b/libs/angular-modal-gallery/src/model/image-internal.class.ts
@@ -31,7 +31,7 @@ import { Image, ModalImage, PlainImage } from './image.class';
 export class InternalLibImage extends Image {
   previouslyLoaded: boolean;
 
-  constructor(id: number, modal: ModalImage, plain?: PlainImage, previouslyLoaded: boolean = false) {
+  constructor(id: number | string, modal: ModalImage, plain?: PlainImage, previouslyLoaded: boolean = false) {
     super(id, modal, plain);
 
     this.previouslyLoaded = previouslyLoaded;

--- a/libs/angular-modal-gallery/src/model/image.class.ts
+++ b/libs/angular-modal-gallery/src/model/image.class.ts
@@ -31,12 +31,11 @@ import { SafeResourceUrl } from '@angular/platform-browser';
  * Both image `id` and `modal` are mandatory, instead `plain` is optional.
  */
 export class Image {
-  id: number;
-
+  id: number|string;
   modal: ModalImage;
   plain?: PlainImage;
-
-  constructor(id: number, modal: ModalImage, plain?: PlainImage) {
+  
+  constructor(id: number|string, modal: ModalImage, plain?: PlainImage) {
     this.id = id;
     this.modal = modal;
     this.plain = plain;

--- a/libs/angular-modal-gallery/src/services/gallery.service.ts
+++ b/libs/angular-modal-gallery/src/services/gallery.service.ts
@@ -23,16 +23,24 @@
  */
 
 import { EventEmitter, Injectable } from '@angular/core';
+import { Image } from '../model/image.class';
 
 export interface InternalGalleryPayload {
   galleryId: number;
   index: number;
 }
 
+export interface InternalGalleryRefresh{
+  galleryId:number|string;
+  imageIndex: number;
+  images:Image[];
+}
+
 @Injectable()
 export class GalleryService {
   navigate: EventEmitter<InternalGalleryPayload> = new EventEmitter<InternalGalleryPayload>();
   close: EventEmitter<number> = new EventEmitter<number>();
+  refresh:EventEmitter<InternalGalleryRefresh> = new EventEmitter<InternalGalleryRefresh>();
 
   openGallery(galleryId: number | undefined, index: number): void {
     if (galleryId === undefined || galleryId < 0 || index < 0) {
@@ -49,5 +57,13 @@ export class GalleryService {
       throw new Error('Cannot close gallery via GalleryService with galleryId<0 or galleryId===undefined');
     }
     this.close.emit(galleryId);
+  }
+
+  refreshGallery(galleryId:number|string,imageIndex:number, images :Image[]):void{
+    this.refresh.emit({
+      galleryId: galleryId,
+      imageIndex:imageIndex,
+      images: images
+    })
   }
 }

--- a/libs/angular-modal-gallery/src/services/gallery.service.ts
+++ b/libs/angular-modal-gallery/src/services/gallery.service.ts
@@ -23,25 +23,20 @@
  */
 
 import { EventEmitter, Injectable } from '@angular/core';
-import { Image } from '../model/image.class';
+
 
 export interface InternalGalleryPayload {
   galleryId: number;
   index: number;
 }
 
-export interface InternalGalleryRefresh{
-  galleryId:number|string;
-  imageIndex: number;
-  images:Image[];
-}
+
 
 @Injectable()
 export class GalleryService {
   navigate: EventEmitter<InternalGalleryPayload> = new EventEmitter<InternalGalleryPayload>();
   close: EventEmitter<number> = new EventEmitter<number>();
-  refresh:EventEmitter<InternalGalleryRefresh> = new EventEmitter<InternalGalleryRefresh>();
-
+ 
   openGallery(galleryId: number | undefined, index: number): void {
     if (galleryId === undefined || galleryId < 0 || index < 0) {
       throw new Error('Cannot open gallery via GalleryService with either index<0 or galleryId<0 or galleryId===undefined');
@@ -57,13 +52,5 @@ export class GalleryService {
       throw new Error('Cannot close gallery via GalleryService with galleryId<0 or galleryId===undefined');
     }
     this.close.emit(galleryId);
-  }
-
-  refreshGallery(galleryId:number|string,imageIndex:number, images :Image[]):void{
-    this.refresh.emit({
-      galleryId: galleryId,
-      imageIndex:imageIndex,
-      images: images
-    })
-  }
+  } 
 }


### PR DESCRIPTION
by adding  
```
<ks-modal-gallery [id]="medicalRecordId" [modalImages]="images"
                    ...
                      [onLoadCurrentImage]="onLoadCurrentImage"
                   ...
></ks-modal-gallery>
```
It allow the user to declare a function witch allow to download a base64 img from outside the component when he open the gallery or when he nagigate between the images (when currentImage change)

The mentionned fonction must be type of 
`onLoadCurrentImage(currentImageId: string): Promise<string>`


Bellow an implementation in an angular component .ts file witch use the <ks-modal-gallery>
```
 onLoadCurrentImage(currentImageId: string): Promise<string> {
    if (currentImageId) {
      return this.myclientApi.getPictureFullScreenById(currentImageId).toPromise().then(
        data => {
          return data.fullscreen;
        },
        error => {
          return undefined;
        } );
    } else {
      return undefined;
    }    
  }
```
the function getPictureFullScreenById is an api call witch return a object having a property "fullscreen"  witch contain the full definition image.
I had to define the return function to make it possible to wait for result in your component

I also remove the previous code from gallery service because i found some bad side effect.
