### PR TITLE
feat(): previews template customization

### DIFF
--- a/projects/ks89/angular-modal-gallery/src/lib/components/modal-gallery/modal-gallery.component.html
+++ b/projects/ks89/angular-modal-gallery/src/lib/components/modal-gallery/modal-gallery.component.html
@@ -34,6 +34,7 @@
         <ks-previews [id]="id"
                      [images]="images"
                      [currentImage]="currentImage"
+                     [customTemplate]="customPreviewsTemplate"
                      (clickPreview)="onClickPreview($event)"></ks-previews>
       </div>
     </div>

--- a/projects/ks89/angular-modal-gallery/src/lib/components/modal-gallery/modal-gallery.component.ts
+++ b/projects/ks89/angular-modal-gallery/src/lib/components/modal-gallery/modal-gallery.component.ts
@@ -1,5 +1,7 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component,
-  HostListener, Inject, OnDestroy, OnInit, PLATFORM_ID, SecurityContext, ViewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy, ChangeDetectorRef, Component,
+  HostListener, Inject, OnDestroy, OnInit, PLATFORM_ID, SecurityContext, ViewChild, TemplateRef
+} from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import { DomSanitizer } from '@angular/platform-browser';
 
@@ -83,6 +85,12 @@ export class ModalGalleryComponent implements OnInit, OnDestroy {
    * Array of `InternalLibImage` representing the model of this library with all images, thumbs and so on.
    */
   images: InternalLibImage[];
+
+  /**
+   * Optional template reference to use to render previews.
+   */
+  customPreviewsTemplate?: TemplateRef<HTMLElement>;
+
   /**
    * `Image` that is visible right now.
    */
@@ -123,6 +131,7 @@ export class ModalGalleryComponent implements OnInit, OnDestroy {
     this.images = (this.dialogContent as ModalGalleryConfig).images as InternalLibImage[];
     this.currentImage = (this.dialogContent as ModalGalleryConfig).currentImage as InternalLibImage;
     this.libConfig = (this.dialogContent as ModalGalleryConfig).libConfig;
+    this.customPreviewsTemplate = (this.dialogContent as ModalGalleryConfig).previewsTemplate;
     this.configService.setConfig(this.id, this.libConfig);
 
     this.updateImagesSubscription = this.modalGalleryService.updateImages$.subscribe((images: Image[]) => {

--- a/projects/ks89/angular-modal-gallery/src/lib/components/previews/previews.component.ts
+++ b/projects/ks89/angular-modal-gallery/src/lib/components/previews/previews.component.ts
@@ -22,7 +22,7 @@
  SOFTWARE.
  */
 
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChange, SimpleChanges } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ContentChild, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChange, SimpleChanges, TemplateRef } from '@angular/core';
 
 import { AccessibleComponent } from '../accessible.component';
 
@@ -66,6 +66,15 @@ export class PreviewsComponent extends AccessibleComponent implements OnInit, On
    */
   @Input()
   images: InternalLibImage[] | undefined;
+
+  /**
+   * Optional template reference for the rendering of previews.
+   * Template may access following context variables:
+   * - preview: the `Image` object
+   * - defaultTemplate: the template used by default to render the preview (in case the need is to wrap it)
+   */
+  @Input()
+  customTemplate?: TemplateRef<HTMLElement>;
 
   /**
    * Output to emit the clicked preview. The payload contains the `ImageEvent` associated to the clicked preview.
@@ -194,6 +203,9 @@ export class PreviewsComponent extends AccessibleComponent implements OnInit, On
    * @param Action action that triggered the source event or `Action.NORMAL` if not specified
    */
   onImageEvent(preview: InternalLibImage, event: KeyboardEvent | MouseEvent, action: Action = Action.NORMAL): void {
+    // It's suggested to stop propagation of the event, so the
+    // Cdk background will not catch a click and close the modal (like it does on Windows Chrome/FF).
+    event?.stopPropagation();
     if (!this.id || !this.images) {
       throw new Error('Internal library error - id and images must be defined');
     }

--- a/projects/ks89/angular-modal-gallery/src/lib/components/previews/previews.html
+++ b/projects/ks89/angular-modal-gallery/src/lib/components/previews/previews.html
@@ -14,7 +14,9 @@
     </a>
 
     <ng-container *ngFor="let preview of previews; trackBy: trackById; let index = index">
-      <img *ngIf="preview?.modal?.img"
+
+      <ng-template #defaultTemplate>
+        <img *ngIf="preview?.modal?.img"
            class="inside preview-image {{isActive(preview) ? 'active' : ''}}{{!previewConfig?.clickable ? ' unclickable' : ''}}"
            [src]="preview.plain?.img ? preview.plain?.img! : preview.modal.img"
            ksFallbackImage [fallbackImg]="preview.plain?.fallbackImg ? preview.plain?.fallbackImg : preview.modal.fallbackImg"
@@ -24,7 +26,18 @@
            [title]="(preview.modal.title || preview.modal.title === '') ? preview.modal.title : ''"
            alt="{{preview.modal.alt ? preview.modal.alt : ''}}"
            [tabIndex]="0" role="img"
-           (click)="onImageEvent(preview, $event, clickAction)" (keyup)="onImageEvent(preview, $event, keyboardAction)"/>
+        />
+      </ng-template>
+
+      <div
+        (click)="onImageEvent(preview, $event, clickAction)"
+        (keyup)="onImageEvent(preview, $event, keyboardAction)"
+      >
+        <ng-container 
+          *ngTemplateOutlet="!customTemplate ? defaultTemplate : customTemplate ; context:{preview, defaultTemplate}">
+        </ng-container>
+      </div>
+
     </ng-container>
 
 

--- a/projects/ks89/angular-modal-gallery/src/lib/components/previews/previews.html
+++ b/projects/ks89/angular-modal-gallery/src/lib/components/previews/previews.html
@@ -15,27 +15,26 @@
 
     <ng-container *ngFor="let preview of previews; trackBy: trackById; let index = index">
 
-      <ng-template #defaultTemplate>
-        <img *ngIf="preview?.modal?.img"
-           class="inside preview-image {{isActive(preview) ? 'active' : ''}}{{!previewConfig?.clickable ? ' unclickable' : ''}}"
-           [src]="preview.plain?.img ? preview.plain?.img! : preview.modal.img"
-           ksFallbackImage [fallbackImg]="preview.plain?.fallbackImg ? preview.plain?.fallbackImg : preview.modal.fallbackImg"
-           ksSize [sizeConfig]="{width: previewConfig?.size ? previewConfig?.size?.width! : defaultPreviewSize.width,
-                                 height: previewConfig?.size ? previewConfig?.size?.height! : defaultPreviewSize.height}"
-           [attr.aria-label]="preview.modal.ariaLabel ? preview.modal.ariaLabel : ''"
-           [title]="(preview.modal.title || preview.modal.title === '') ? preview.modal.title : ''"
-           alt="{{preview.modal.alt ? preview.modal.alt : ''}}"
-           [tabIndex]="0" role="img"
-        />
-      </ng-template>
-
-      <div
+      <div class="preview-container {{!previewConfig?.clickable ? ' unclickable' : ''}}"
         (click)="onImageEvent(preview, $event, clickAction)"
         (keyup)="onImageEvent(preview, $event, keyboardAction)"
       >
         <ng-container 
           *ngTemplateOutlet="!customTemplate ? defaultTemplate : customTemplate ; context:{preview, defaultTemplate}">
         </ng-container>
+        <ng-template #defaultTemplate>
+          <img *ngIf="preview?.modal?.img"
+              class="inside preview-image {{isActive(preview) ? 'active' : ''}}"
+              [src]="preview.plain?.img ? preview.plain?.img! : preview.modal.img"
+              ksFallbackImage [fallbackImg]="preview.plain?.fallbackImg ? preview.plain?.fallbackImg : preview.modal.fallbackImg"
+              ksSize [sizeConfig]="{width: previewConfig?.size ? previewConfig?.size?.width! : defaultPreviewSize.width,
+                                    height: previewConfig?.size ? previewConfig?.size?.height! : defaultPreviewSize.height}"
+              [attr.aria-label]="preview.modal.ariaLabel ? preview.modal.ariaLabel : ''"
+              [title]="(preview.modal.title || preview.modal.title === '') ? preview.modal.title : ''"
+              alt="{{preview.modal.alt ? preview.modal.alt : ''}}"
+              [tabIndex]="0" role="img"
+          />
+        </ng-template>
       </div>
 
     </ng-container>

--- a/projects/ks89/angular-modal-gallery/src/lib/components/previews/previews.scss
+++ b/projects/ks89/angular-modal-gallery/src/lib/components/previews/previews.scss
@@ -108,27 +108,28 @@ $nav-side-margin: 10px;
     justify-content: center;
     margin-bottom: $container-margin-bottom;
 
-    > .preview-image {
-      cursor: pointer;
+    .preview-container {
       margin-left: $preview-image-side-margin;
       margin-right: $preview-image-side-margin;
-      opacity: $preview-image-opacity;
-      height: $preview-image-height;
-      //animation: fadein-semi-visible08 $preview-image-fade-in-time;
-
-      &.active {
-        opacity: $preview-image-hover-opacity;
-        //animation: fadein-visible $preview-image-fade-in-time;
-      }
-
+      cursor: pointer;
       &.unclickable {
         cursor: not-allowed;
       }
+      .preview-image {
+        opacity: $preview-image-opacity;
+        height: $preview-image-height;
+        //animation: fadein-semi-visible08 $preview-image-fade-in-time;
 
-      &:hover {
-        opacity: $preview-image-active-opacity;
-        transition: all .5s ease;
-        transition-property: opacity;
+        &.active {
+          opacity: $preview-image-hover-opacity;
+          //animation: fadein-visible $preview-image-fade-in-time;
+        }
+
+        &:hover {
+          opacity: $preview-image-active-opacity;
+          transition: all .5s ease;
+          transition-property: opacity;
+        }
       }
     }
 

--- a/projects/ks89/angular-modal-gallery/src/lib/model/modal-gallery-config.interface.ts
+++ b/projects/ks89/angular-modal-gallery/src/lib/model/modal-gallery-config.interface.ts
@@ -22,6 +22,7 @@
  SOFTWARE.
  */
 
+import { TemplateRef } from '@angular/core';
 import { Image } from './image.class';
 import { ModalLibConfig } from './lib-config.interface';
 
@@ -30,4 +31,11 @@ export interface ModalGalleryConfig {
   images: Image[];
   currentImage: Image;
   libConfig?: ModalLibConfig;
+  /**
+   * Optional template reference for the rendering of previews.
+   * Template may access following context variables:
+   * - "preview": the `Image` object of the preview
+   * - "defaultTemplate": the template used by default to render the preview (in case the need is to augment it)
+   */
+  previewsTemplate?: TemplateRef<HTMLElement>;
 }

--- a/src/app/modal-gallery/modal-gallery.component.ts
+++ b/src/app/modal-gallery/modal-gallery.component.ts
@@ -22,6 +22,8 @@
  SOFTWARE.
  */
 
+import { TemplateRef } from '@angular/core';
+import { ViewChild } from '@angular/core';
 import { Component, OnDestroy } from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 
@@ -46,6 +48,12 @@ import * as libConfigs from './libconfigs';
   styleUrls: ['./modal-gallery.scss']
 })
 export class ModalGalleryExampleComponent implements OnDestroy {
+  /**
+   * A custom template to illustrate the customization of previews rendering.
+   */
+  @ViewChild('previewsTemplate')
+  previewsTemplate?: TemplateRef<HTMLElement>;
+
   imageIndex = 0;
   galleryId = 1;
   isPlaying = true;
@@ -508,11 +516,13 @@ export class ModalGalleryExampleComponent implements OnDestroy {
       return;
     }
     const imageToShow: Image = imagesArrayToUse[imageIndex];
+    const previewsTemplate = (id === 902 ? this.previewsTemplate : undefined);
     const dialogRef: ModalGalleryRef = this.modalGalleryService.open({
       id,
       images: imagesArrayToUse,
       currentImage: imageToShow,
-      libConfig
+      libConfig,
+      previewsTemplate,
     } as ModalGalleryConfig) as ModalGalleryRef;
   }
 

--- a/src/app/modal-gallery/modal-gallery.component.ts
+++ b/src/app/modal-gallery/modal-gallery.component.ts
@@ -516,13 +516,11 @@ export class ModalGalleryExampleComponent implements OnDestroy {
       return;
     }
     const imageToShow: Image = imagesArrayToUse[imageIndex];
-    const previewsTemplate = (id === 902 ? this.previewsTemplate : undefined);
     const dialogRef: ModalGalleryRef = this.modalGalleryService.open({
       id,
       images: imagesArrayToUse,
       currentImage: imageToShow,
       libConfig,
-      previewsTemplate,
     } as ModalGalleryConfig) as ModalGalleryRef;
   }
 
@@ -717,6 +715,25 @@ export class ModalGalleryExampleComponent implements OnDestroy {
 
   trackById(index: number, item: Image): number {
     return item.id;
+  }
+
+  openModalWithPreviewsTemplate(id: number, imagesArrayToUse: Image[], imageIndex: number, libConfig?: ModalLibConfig): void {
+    if(imagesArrayToUse.length === 0) {
+      console.error('Cannot open modal-gallery because images array cannot be empty');
+      return;
+    }
+    if(imageIndex > imagesArrayToUse.length - 1) {
+      console.error('Cannot open modal-gallery because imageIndex must be valid');
+      return;
+    }
+    const imageToShow: Image = imagesArrayToUse[imageIndex];
+    const dialogRef: ModalGalleryRef = this.modalGalleryService.open({
+      id,
+      images: imagesArrayToUse,
+      currentImage: imageToShow,
+      libConfig,
+      previewsTemplate: this.previewsTemplate,
+    } as ModalGalleryConfig) as ModalGalleryRef;
   }
 
   ngOnDestroy(): void {

--- a/src/app/modal-gallery/modal-gallery.html
+++ b/src/app/modal-gallery/modal-gallery.html
@@ -315,3 +315,16 @@
   <h3>F2 - (id=901) - Experimental demo - an array of Images with the same source file (different classes/ids and paths with appended '?imageIndex' to prevent caching issues)</h3>
   <button (click)="openModal(901, sameImages, 0)">Open modalgallery</button>
 </section>
+<section>
+  <h3>F3 - (id=902) - Experimental demo - 'previews' rendering customization (via Angular templates)</h3>
+  <ng-template #previewsTemplate let-preview="preview" let-defaultTemplate="defaultTemplate">
+    <div class="preview-block">
+      <div class="preview-description">{{preview?.modal?.description ?? '&nbsp;'}}</div>
+      <div class="preview-default">
+        <ng-container *ngTemplateOutlet="defaultTemplate"></ng-container>
+      </div>
+    </div>
+  </ng-template>
+  <button (click)="openModal(902, images, imageIndex)">Open modalgallery</button>
+</section>
+

--- a/src/app/modal-gallery/modal-gallery.html
+++ b/src/app/modal-gallery/modal-gallery.html
@@ -325,6 +325,6 @@
       </div>
     </div>
   </ng-template>
-  <button (click)="openModal(902, images, imageIndex)">Open modalgallery</button>
+  <button (click)="openModalWithPreviewsTemplate(902, images, imageIndex)">Open modalgallery</button>
 </section>
 

--- a/src/app/modal-gallery/modal-gallery.scss
+++ b/src/app/modal-gallery/modal-gallery.scss
@@ -163,3 +163,15 @@ button {
 .title {
   margin-top: 40px;
 }
+
+.preview-block {
+  margin-right: 10px;
+}
+.preview-description {
+  color: #fff;
+  margin-bottom: 3px;
+}
+.preview-description,
+.preview-default {
+  text-align: center;
+}


### PR DESCRIPTION
Hello !
Ok, a new PR for this feature, on the right branch and with the example as an experimental feature "F3".

I have also written 2 unit tests for the previews component; they use intermediary components that build a template (as an easy way to get TemplateRef to give as the appropriate PreviewsComponent input). One uses a totally "different" template. The other one uses the "default" template. Each test checks that the proper HTML elements are present.

A couple questions!
- I used example id 902 for this new example. Within openModal(), I didn't add yet another optional parameters to provide a templateRef, but has based it directly on the 902 id. Optional parameter/magic number, what's your choice here?
- If you will, I'd like to propose a description on how to use the previews customization, like on a new left item here (https://ks89.github.io/angular-modal-gallery-2021-v9.github.io/features), but where could I do that? It appears this page is not part of this repo?

Also, 2 hmm... almost related things:
- what do you think of adding a 'cursor: pointer' css to the preview images (and actually to the whole preview container I set up, which reacts to (click) and (keyup)) ?
- about the initial need for preview customization, I've noted this:
_Ultimately, I'd like to use picture-specific information which (if I'm not wrong) can not fit anywhere in the ModalImage object, such as the picture date for instance. So to fully be able to do so, an evolution to add a custom Object in ModalImage, which data could be used in template customizations, would be necessary, so that's to be discussed._
What's your thought about that?

Be well !