### PR TITLE
Previews fixes

### DIFF
--- a/projects/ks89/angular-modal-gallery/src/lib/components/modal-gallery/modal-gallery.component.html
+++ b/projects/ks89/angular-modal-gallery/src/lib/components/modal-gallery/modal-gallery.component.html
@@ -34,6 +34,7 @@
         <ks-previews [id]="id"
                      [images]="images"
                      [currentImage]="currentImage"
+                     [customTemplate]="customPreviewsTemplate"
                      (clickPreview)="onClickPreview($event)"></ks-previews>
       </div>
     </div>

--- a/projects/ks89/angular-modal-gallery/src/lib/components/modal-gallery/modal-gallery.component.ts
+++ b/projects/ks89/angular-modal-gallery/src/lib/components/modal-gallery/modal-gallery.component.ts
@@ -1,5 +1,7 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component,
-  HostListener, Inject, OnDestroy, OnInit, PLATFORM_ID, SecurityContext, ViewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy, ChangeDetectorRef, Component,
+  HostListener, Inject, OnDestroy, OnInit, PLATFORM_ID, SecurityContext, ViewChild, TemplateRef
+} from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import { DomSanitizer } from '@angular/platform-browser';
 
@@ -83,6 +85,12 @@ export class ModalGalleryComponent implements OnInit, OnDestroy {
    * Array of `InternalLibImage` representing the model of this library with all images, thumbs and so on.
    */
   images: InternalLibImage[];
+
+  /**
+   * Optional template reference to use to render previews.
+   */
+  customPreviewsTemplate?: TemplateRef<HTMLElement>;
+
   /**
    * `Image` that is visible right now.
    */
@@ -123,6 +131,7 @@ export class ModalGalleryComponent implements OnInit, OnDestroy {
     this.images = (this.dialogContent as ModalGalleryConfig).images as InternalLibImage[];
     this.currentImage = (this.dialogContent as ModalGalleryConfig).currentImage as InternalLibImage;
     this.libConfig = (this.dialogContent as ModalGalleryConfig).libConfig;
+    this.customPreviewsTemplate = (this.dialogContent as ModalGalleryConfig).previewsTemplate;
     this.configService.setConfig(this.id, this.libConfig);
 
     this.updateImagesSubscription = this.modalGalleryService.updateImages$.subscribe((images: Image[]) => {

--- a/projects/ks89/angular-modal-gallery/src/lib/components/previews/previews.component.spec.ts
+++ b/projects/ks89/angular-modal-gallery/src/lib/components/previews/previews.component.spec.ts
@@ -738,7 +738,15 @@ describe('PreviewsComponent', () => {
 
         previews = element.queryAll(By.css('img'));
 
-        previews[1].nativeElement.click();
+        // previews[1].nativeElement.click();
+        comp.ngOnChanges({
+          currentImage: {
+            previousValue: IMAGES[0],
+            currentValue: IMAGES[1],
+            firstChange: false,
+            isFirstChange: () => false
+          }
+        } as SimpleChanges);
         checkPreviewStateAfterClick(previews, IMAGES[0], IMAGES[1], 0, 3, 1);
         // images = IMAGES.slice(0, 3);
         // for (let i = 0; i < images.length; i++) {
@@ -853,6 +861,101 @@ describe('PreviewsComponent', () => {
         checkPreview(previews[i], previewImages[i], i === 0, DEFAULT_PREVIEW_SIZE);
       }
     });
+
+    [4, 5].forEach((previewNumber: number) => {
+      it(`should display a constant number of previews (${previewNumber}), independent of current image index`, waitForAsync(() => {
+        const configService = fixture.debugElement.injector.get(ConfigService);
+        const previewConfig = Object.assign({}, PREVIEWS_CONFIG_VISIBLE, { number: previewNumber }) as PreviewConfig;
+        configService.setConfig(GALLERY_ID, {
+          previewConfig,
+          accessibilityConfig: KS_DEFAULT_ACCESSIBILITY_CONFIG,
+          slideConfig: SLIDE_CONFIG
+        });
+        comp.id = GALLERY_ID;
+        comp.currentImage = IMAGES[0];
+        comp.images = IMAGES;
+        comp.ngOnInit();
+        expect(comp.previews.length).toBe(previewNumber);
+
+        // click on the second picture
+        comp.currentImage = IMAGES[1]; // set component input
+        comp.ngOnChanges({ // trigger changes manually (not done automatically in tests)
+          currentImage: {
+            previousValue: IMAGES[0],
+            currentValue: IMAGES[1],
+            firstChange: false,
+            isFirstChange: () => false
+          }
+        } as SimpleChanges);
+        // at the time of writing this test, a change is detected within 'images', yet with the same value
+        comp.ngOnChanges({
+          images: {
+            previousValue: IMAGES,
+            currentValue: IMAGES,
+            firstChange: false,
+            isFirstChange: () => false
+          }
+        } as SimpleChanges);
+        expect(comp.previews.length).toBe(previewNumber);
+
+        // click on the third picture
+        comp.currentImage = IMAGES[2]; // set component input
+        comp.ngOnChanges({ // trigger changes manually (not done automatically in tests)
+          currentImage: {
+            previousValue: IMAGES[1],
+            currentValue: IMAGES[2],
+            firstChange: false,
+            isFirstChange: () => false
+          }
+        } as SimpleChanges);
+        // at the time of writing this test, a change is detected within 'images', yet with the same value
+        comp.ngOnChanges({
+          images: {
+            previousValue: IMAGES,
+            currentValue: IMAGES,
+            firstChange: false,
+            isFirstChange: () => false
+          }
+        } as SimpleChanges);
+        expect(comp.previews.length).toBe(previewNumber);
+      }));
+    });
+
+    it('should allow to navigate previews from first to last and back', () => {
+      const configService = fixture.debugElement.injector.get(ConfigService);
+      configService.setConfig(GALLERY_ID, {
+        previewConfig: PREVIEWS_CONFIG_VISIBLE,
+        accessibilityConfig: KS_DEFAULT_ACCESSIBILITY_CONFIG,
+        slideConfig: SLIDE_CONFIG
+      });
+      comp.id = GALLERY_ID;
+      comp.currentImage = IMAGES[0];
+      comp.images = IMAGES;
+      comp.ngOnInit();
+      fixture.detectChanges();
+      const element: DebugElement = fixture.debugElement;
+      let previews: DebugElement[] = element.queryAll(By.css('img'));
+
+      const leftArrow = element.query(By.css('a.nav-left')).nativeElement as HTMLAnchorElement;
+      const rightArrow = element.query(By.css('a.nav-right')).nativeElement as HTMLAnchorElement;
+      checkPreviewStateAfterClick(previews, IMAGES[0], IMAGES[0], 0, 3, 0);
+
+      // click right until the last preview is reached
+      rightArrow.click();
+      checkPreviewStateAfterClick(previews, IMAGES[0], IMAGES[0], 1, 4, 0);
+      rightArrow.click();
+      checkPreviewStateAfterClick(previews, IMAGES[0], IMAGES[0], 2, 5, 0);
+      // click left until the first preview is reached
+      leftArrow.click();
+      checkPreviewStateAfterClick(previews, IMAGES[0], IMAGES[0], 1, 4, 0);
+      leftArrow.click();
+      checkPreviewStateAfterClick(previews, IMAGES[0], IMAGES[0], 0, 3, 0);
+      // click right again and check previews have changed accordingly
+      rightArrow.click();
+      checkPreviewStateAfterClick(previews, IMAGES[0], IMAGES[0], 1, 4, 0);
+      
+    });
+
   });
 
   describe('---NO---', () => {

--- a/projects/ks89/angular-modal-gallery/src/lib/components/previews/previews.component.spec.ts
+++ b/projects/ks89/angular-modal-gallery/src/lib/components/previews/previews.component.spec.ts
@@ -956,6 +956,41 @@ describe('PreviewsComponent', () => {
       
     });
 
+    it('should always display previews navigation arrows, in infinite sliding mode (nbPreviews < nbImages)', () => {
+      const configService = fixture.debugElement.injector.get(ConfigService);
+      configService.setConfig(GALLERY_ID, {
+        previewConfig: PREVIEWS_CONFIG_VISIBLE,
+        accessibilityConfig: KS_DEFAULT_ACCESSIBILITY_CONFIG,
+        slideConfig: SLIDE_CONFIG_INFINITE
+      });
+      comp.id = GALLERY_ID;
+      comp.currentImage = IMAGES[0];
+      comp.images = IMAGES;
+      comp.ngOnInit();
+      fixture.detectChanges();
+      const element: DebugElement = fixture.debugElement;
+      const leftArrow = element.query(By.css('a.nav-left')).nativeElement as HTMLAnchorElement;
+      const rightArrow = element.query(By.css('a.nav-right')).nativeElement as HTMLAnchorElement;
+      let leftArrowDiv = element.query(By.css('a.nav-left > div')).nativeElement as HTMLAnchorElement;
+      let rightArrowDiv = element.query(By.css('a.nav-right > div')).nativeElement as HTMLAnchorElement;
+      // check that arrows are initially visible
+      expect(leftArrowDiv.classList).toContain('left-arrow-preview-image');
+      expect(rightArrowDiv.classList).toContain('right-arrow-preview-image');
+      // click right until the last preview is reached, each time check that arrows are visible
+      rightArrow.click();
+      fixture.detectChanges();
+      leftArrowDiv = element.query(By.css('a.nav-left > div')).nativeElement as HTMLAnchorElement;
+      rightArrowDiv = element.query(By.css('a.nav-right > div')).nativeElement as HTMLAnchorElement;
+      expect(leftArrowDiv.classList).toContain('left-arrow-preview-image');
+      expect(rightArrowDiv.classList).toContain('right-arrow-preview-image');
+      rightArrow.click();
+      fixture.detectChanges();
+      leftArrowDiv = element.query(By.css('a.nav-left > div')).nativeElement as HTMLAnchorElement;
+      rightArrowDiv = element.query(By.css('a.nav-right > div')).nativeElement as HTMLAnchorElement;
+      expect(leftArrowDiv.classList).toContain('left-arrow-preview-image');
+      expect(rightArrowDiv.classList).toContain('right-arrow-preview-image');
+    });
+
   });
 
   describe('---NO---', () => {

--- a/projects/ks89/angular-modal-gallery/src/lib/components/previews/previews.component.ts
+++ b/projects/ks89/angular-modal-gallery/src/lib/components/previews/previews.component.ts
@@ -22,7 +22,7 @@
  SOFTWARE.
  */
 
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChange, SimpleChanges } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ContentChild, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChange, SimpleChanges, TemplateRef } from '@angular/core';
 
 import { AccessibleComponent } from '../accessible.component';
 
@@ -66,6 +66,15 @@ export class PreviewsComponent extends AccessibleComponent implements OnInit, On
    */
   @Input()
   images: InternalLibImage[] | undefined;
+
+  /**
+   * Optional template reference for the rendering of previews.
+   * Template may access following context variables:
+   * - preview: the `Image` object
+   * - defaultTemplate: the template used by default to render the preview (in case the need is to wrap it)
+   */
+  @Input()
+  customTemplate?: TemplateRef<HTMLElement>;
 
   /**
    * Output to emit the clicked preview. The payload contains the `ImageEvent` associated to the clicked preview.
@@ -194,6 +203,9 @@ export class PreviewsComponent extends AccessibleComponent implements OnInit, On
    * @param Action action that triggered the source event or `Action.NORMAL` if not specified
    */
   onImageEvent(preview: InternalLibImage, event: KeyboardEvent | MouseEvent, action: Action = Action.NORMAL): void {
+    // It's suggested to stop propagation of the event, so the
+    // Cdk background will not catch a click and close the modal (like it does on Windows Chrome/FF).
+    event?.stopPropagation();
     if (!this.id || !this.images) {
       throw new Error('Internal library error - id and images must be defined');
     }

--- a/projects/ks89/angular-modal-gallery/src/lib/components/previews/previews.component.ts
+++ b/projects/ks89/angular-modal-gallery/src/lib/components/previews/previews.component.ts
@@ -229,6 +229,30 @@ export class PreviewsComponent extends AccessibleComponent implements OnInit, On
   }
 
   /**
+   * Indicates if the previews 'left arrow' should be displayed or not.
+   * @returns 
+   */
+  displayLeftPreviewsArrow(): boolean {
+    // Don't show arrows if requested previews number equals or is greated than total number of imgaes
+    if(this.previewConfig?.number !== undefined && this.images && this.previewConfig?.number >= this.images?.length) {
+      return false;
+    }
+    return (this.previewConfig?.arrows && this.start > 0) || !!this.slideConfig?.infinite;
+  }
+
+  /**
+   * Indicates if the previews 'right arrow' should be displayed or not.
+   * @returns 
+   */
+  displayRightPreviewsArrow(): boolean {
+    // Don't show arrows if requested previews number equals or is greated than total number of imgaes
+    if(this.previewConfig?.number !== undefined && this.images && this.previewConfig?.number >= this.images?.length) {
+      return false;
+    }
+    return (this.previewConfig?.arrows && this.images && this.end < this.images.length) || !!this.slideConfig?.infinite;
+  }
+
+  /**
    * Private method to init previews based on the currentImage and the full array of images.
    * The current image in mandatory to show always the current preview (as highlighted).
    * @param InternalLibImage currentImage to decide how to show previews, because I always want to see the current image as highlighted

--- a/projects/ks89/angular-modal-gallery/src/lib/components/previews/previews.component.ts
+++ b/projects/ks89/angular-modal-gallery/src/lib/components/previews/previews.component.ts
@@ -112,12 +112,12 @@ export class PreviewsComponent extends AccessibleComponent implements OnInit, On
    */
   previews: InternalLibImage[] = [];
   /**
-   * Start index of the input images used to display previews.
+   * Start index (included) of the input images used to display previews.
    */
     // @ts-ignore
   start: number;
   /**
-   * End index of the input images used to display previews.
+   * End index (excluded) of the input images used to display previews.
    */
     // @ts-ignore
   end: number;
@@ -170,28 +170,12 @@ export class PreviewsComponent extends AccessibleComponent implements OnInit, On
    * In particular, it's called when any data-bound property of a directive changes!!!
    */
   ngOnChanges(changes: SimpleChanges): void {
-    const images: SimpleChange = changes.images;
-    const currentImage: SimpleChange = changes.currentImage;
 
-    let prev;
-    let current;
+    let currentImage = changes.currentImage?.currentValue ?? this.currentImage;
+    let images = changes.images?.currentValue ?? this.images;
 
-    if (currentImage) {
-      prev = currentImage.previousValue;
-      current = currentImage.currentValue;
-    } else {
-      current = this.currentImage;
-    }
-
-    if (current && images && images.previousValue && images.currentValue) {
-      // I'm in this if statement, if input images are changed (for instance, because I removed one of them with the 'delete button',
-      // or because users changed the images array while modal gallery is still open).
-      // In this case, I have to re-init previews, because the input array of images is changed.
-      this.initPreviews(current, images.currentValue);
-    }
-
-    if (prev && current && prev.id !== current.id) {
-      this.updatePreviews(prev, current);
+    if(this.previewConfig && currentImage && images) {
+      this.initPreviews( currentImage, images);
     }
   }
 
@@ -251,80 +235,51 @@ export class PreviewsComponent extends AccessibleComponent implements OnInit, On
    * @param InternalLibImage[] images is the array of all images.
    */
   private initPreviews(currentImage: InternalLibImage, images: InternalLibImage[]): void {
-    let index: number;
-    try {
-      index = getIndex(currentImage, images);
-    } catch (err) {
-      throw err;
-    }
-    switch (index) {
-      case 0:
-        // first image
-        this.setBeginningIndexesPreviews();
-        break;
-      case images.length - 1:
-        // last image
-        this.setEndIndexesPreviews();
-        break;
-      default:
-        // other images
-        this.setIndexesPreviews();
-        break;
-    }
+    this.setIndexesPreviews(currentImage, images);
     this.previews = images.filter((img: InternalLibImage, i: number) => i >= this.start && i < this.end);
-  }
-
-  /**
-   * Private method to init both `start` and `end` to the beginning.
-   */
-  private setBeginningIndexesPreviews(): void {
-    if (!this.previewConfig || !this.images) {
-      throw new Error('Internal library error - previewConfig and images must be defined');
-    }
-    this.start = 0;
-    this.end = Math.min(this.previewConfig.number as number, this.images.length);
-  }
-
-  /**
-   * Private method to init both `start` and `end` to the end.
-   */
-  private setEndIndexesPreviews(): void {
-    if (!this.previewConfig || !this.images) {
-      throw new Error('Internal library error - previewConfig and images must be defined');
-    }
-    this.start = this.images.length - 1 - ((this.previewConfig.number as number) - 1);
-    this.end = this.images.length;
   }
 
   /**
    * Private method to update both `start` and `end` based on the currentImage.
    */
-  private setIndexesPreviews(): void {
-    if (!this.previewConfig || !this.images || !this.currentImage) {
+  private setIndexesPreviews(currentImage: InternalLibImage, images: InternalLibImage[]): void {
+    if (!this.previewConfig || !images || !currentImage) {
       throw new Error('Internal library error - previewConfig, currentImage and images must be defined');
     }
-    this.start = getIndex(this.currentImage, this.images) - Math.floor((this.previewConfig.number as number) / 2);
-    this.end = getIndex(this.currentImage, this.images) + Math.floor((this.previewConfig.number as number) / 2) + 1;
+    const previewsNumber = this.previewConfig.number as number;
+    let start = getIndex(currentImage, images) - Math.floor(previewsNumber / 2);
+    // start is, at a minimum, the first index
+    if(start < 0) start = 0;
+    // end index
+    let end = start + previewsNumber;
+    // end is, at a maximum, the last index
+    if(end > images.length) {
+      start -= end - images.length;
+      if(start < 0) start = 0; // start is, at a minimum, the first index
+      end = images.length;
+    }
+    this.start = start;
+    this.end = end;
   }
 
   /**
    * Private method to update the visible previews navigating to the right (next).
    */
   private next(): void {
-    if (!this.images) {
+    if (!this.images || !this.previewConfig) {
       throw new Error('Internal library error - images must be defined');
     }
-    // check if nextImage should be blocked
-    if (this.isPreventSliding(this.images.length - 1)) {
-      return;
+    if(this.end >= this.images.length) {
+      // check if nextImage should be blocked
+      const preventSliding = !!this.slideConfig && this.slideConfig.infinite === false;
+      if(preventSliding) {
+        return;
+      }
+      this.start = 0;
+    } else {
+      this.start++;
     }
-
-    if (this.end === this.images.length) {
-      return;
-    }
-
-    this.start++;
-    this.end = Math.min(this.end + 1, this.images.length);
+    this.end = this.start + Math.min((this.previewConfig.number as number), this.images.length);
 
     this.previews = this.images.filter((img: InternalLibImage, i: number) => i >= this.start && i < this.end);
   }
@@ -333,74 +288,22 @@ export class PreviewsComponent extends AccessibleComponent implements OnInit, On
    * Private method to update the visible previews navigating to the left (previous).
    */
   private previous(): void {
-    if (!this.images) {
+    if (!this.images || !this.previewConfig) {
       throw new Error('Internal library error - images must be defined');
     }
-    // check if prevImage should be blocked
-    if (this.isPreventSliding(0)) {
-      return;
+    if(this.start <= 0) {
+      // check if prevImage should be blocked
+      const preventSliding = !!this.slideConfig && this.slideConfig.infinite === false;
+      if(preventSliding) {
+        return;
+      }
+      this.end = this.images.length;
+    } else {
+      this.end--;
     }
-
-    if (this.start === 0) {
-      return;
-    }
-
-    this.start = Math.max(this.start - 1, 0);
-    this.end = Math.min(this.end - 1, this.images.length);
+    this.start = this.end - Math.min((this.previewConfig.number as number), this.images.length);
 
     this.previews = this.images.filter((img: InternalLibImage, i: number) => i >= this.start && i < this.end);
   }
 
-  /**
-   * Private method to block/permit sliding between previews.
-   * @param number boundaryIndex is the first or the last index of `images` input array
-   * @returns boolean if true block sliding, otherwise not
-   */
-  private isPreventSliding(boundaryIndex: number): boolean {
-    if (!this.images || !this.currentImage) {
-      throw new Error('Internal library error - images and currentImage must be defined');
-    }
-    return !!this.slideConfig && this.slideConfig.infinite === false && getIndex(this.currentImage, this.images) === boundaryIndex;
-  }
-
-  /**
-   * Private method to handle navigation changing the previews array and other variables.
-   */
-  private updatePreviews(prev: InternalLibImage, current: InternalLibImage): void {
-    if (!this.images) {
-      throw new Error('Internal library error - images must be defined');
-    }
-    // to manage infinite sliding I have to reset both `start` and `end` at the beginning
-    // to show again previews from the first image.
-    // This happens when you navigate over the last image to return to the first one
-    let prevIndex: number;
-    let currentIndex: number;
-    try {
-      prevIndex = getIndex(prev, this.images);
-      currentIndex = getIndex(current, this.images);
-    } catch (err) {
-      console.error('Cannot get previous and current image indexes in previews');
-      throw err;
-    }
-    if (prevIndex === this.images.length - 1 && currentIndex === 0) {
-      // first image
-      this.setBeginningIndexesPreviews();
-      this.previews = this.images.filter((img: InternalLibImage, i: number) => i >= this.start && i < this.end);
-      return;
-    }
-    // the same for the opposite case, when you navigate back from the fist image to go to the last one.
-    if (prevIndex === 0 && currentIndex === this.images.length - 1) {
-      // last image
-      this.setEndIndexesPreviews();
-      this.previews = this.images.filter((img: InternalLibImage, i: number) => i >= this.start && i < this.end);
-      return;
-    }
-
-    // otherwise manage standard scenarios
-    if (prevIndex > currentIndex) {
-      this.previous();
-    } else if (prevIndex < currentIndex) {
-      this.next();
-    }
-  }
 }

--- a/projects/ks89/angular-modal-gallery/src/lib/components/previews/previews.html
+++ b/projects/ks89/angular-modal-gallery/src/lib/components/previews/previews.html
@@ -6,9 +6,9 @@
   <ng-container *ngIf="previewConfig?.visible">
     <a class="nav-left"
        [attr.aria-label]="accessibilityConfig?.previewScrollPrevAriaLabel"
-       [tabIndex]="previewConfig?.arrows && start > 0 ? 0 : -1" role="button"
+       [tabIndex]="displayLeftPreviewsArrow() ? 0 : -1" role="button"
        (click)="onNavigationEvent('left', $event)" (keyup)="onNavigationEvent('left', $event)">
-      <div class="inside {{previewConfig?.arrows && start > 0 ? 'left-arrow-preview-image' : 'empty-arrow-preview-image'}}"
+      <div class="inside {{ displayLeftPreviewsArrow() ? 'left-arrow-preview-image' : 'empty-arrow-preview-image'}}"
            aria-hidden="true"
            [title]="accessibilityConfig?.previewScrollPrevTitle"></div>
     </a>
@@ -42,9 +42,9 @@
 
     <a class="nav-right"
        [attr.aria-label]="accessibilityConfig?.previewScrollNextAriaLabel"
-       [tabIndex]="previewConfig?.arrows && end < images.length ? 0 : -1" role="button"
+       [tabIndex]="displayRightPreviewsArrow() ? 0 : -1" role="button"
        (click)="onNavigationEvent('right', $event)" (keyup)="onNavigationEvent('right', $event)">
-      <div class="inside {{previewConfig?.arrows! && end < images.length ? 'right-arrow-preview-image' : 'empty-arrow-preview-image'}}"
+      <div class="inside {{ displayRightPreviewsArrow() ? 'right-arrow-preview-image' : 'empty-arrow-preview-image'}}"
            aria-hidden="true"
            [title]="accessibilityConfig?.previewScrollNextTitle"></div>
     </a>

--- a/projects/ks89/angular-modal-gallery/src/lib/components/previews/previews.html
+++ b/projects/ks89/angular-modal-gallery/src/lib/components/previews/previews.html
@@ -14,7 +14,9 @@
     </a>
 
     <ng-container *ngFor="let preview of previews; trackBy: trackById; let index = index">
-      <img *ngIf="preview?.modal?.img"
+
+      <ng-template #defaultTemplate>
+        <img *ngIf="preview?.modal?.img"
            class="inside preview-image {{isActive(preview) ? 'active' : ''}}{{!previewConfig?.clickable ? ' unclickable' : ''}}"
            [src]="preview.plain?.img ? preview.plain?.img! : preview.modal.img"
            ksFallbackImage [fallbackImg]="preview.plain?.fallbackImg ? preview.plain?.fallbackImg : preview.modal.fallbackImg"
@@ -24,7 +26,18 @@
            [title]="(preview.modal.title || preview.modal.title === '') ? preview.modal.title : ''"
            alt="{{preview.modal.alt ? preview.modal.alt : ''}}"
            [tabIndex]="0" role="img"
-           (click)="onImageEvent(preview, $event, clickAction)" (keyup)="onImageEvent(preview, $event, keyboardAction)"/>
+        />
+      </ng-template>
+
+      <div
+        (click)="onImageEvent(preview, $event, clickAction)"
+        (keyup)="onImageEvent(preview, $event, keyboardAction)"
+      >
+        <ng-container 
+          *ngTemplateOutlet="!customTemplate ? defaultTemplate : customTemplate ; context:{preview, defaultTemplate}">
+        </ng-container>
+      </div>
+
     </ng-container>
 
 

--- a/projects/ks89/angular-modal-gallery/src/lib/components/previews/previews.html
+++ b/projects/ks89/angular-modal-gallery/src/lib/components/previews/previews.html
@@ -15,27 +15,26 @@
 
     <ng-container *ngFor="let preview of previews; trackBy: trackById; let index = index">
 
-      <ng-template #defaultTemplate>
-        <img *ngIf="preview?.modal?.img"
-           class="inside preview-image {{isActive(preview) ? 'active' : ''}}{{!previewConfig?.clickable ? ' unclickable' : ''}}"
-           [src]="preview.plain?.img ? preview.plain?.img! : preview.modal.img"
-           ksFallbackImage [fallbackImg]="preview.plain?.fallbackImg ? preview.plain?.fallbackImg : preview.modal.fallbackImg"
-           ksSize [sizeConfig]="{width: previewConfig?.size ? previewConfig?.size?.width! : defaultPreviewSize.width,
-                                 height: previewConfig?.size ? previewConfig?.size?.height! : defaultPreviewSize.height}"
-           [attr.aria-label]="preview.modal.ariaLabel ? preview.modal.ariaLabel : ''"
-           [title]="(preview.modal.title || preview.modal.title === '') ? preview.modal.title : ''"
-           alt="{{preview.modal.alt ? preview.modal.alt : ''}}"
-           [tabIndex]="0" role="img"
-        />
-      </ng-template>
-
-      <div
+      <div class="preview-container {{!previewConfig?.clickable ? ' unclickable' : ''}}"
         (click)="onImageEvent(preview, $event, clickAction)"
         (keyup)="onImageEvent(preview, $event, keyboardAction)"
       >
         <ng-container 
           *ngTemplateOutlet="!customTemplate ? defaultTemplate : customTemplate ; context:{preview, defaultTemplate}">
         </ng-container>
+        <ng-template #defaultTemplate>
+          <img *ngIf="preview?.modal?.img"
+              class="inside preview-image {{isActive(preview) ? 'active' : ''}}"
+              [src]="preview.plain?.img ? preview.plain?.img! : preview.modal.img"
+              ksFallbackImage [fallbackImg]="preview.plain?.fallbackImg ? preview.plain?.fallbackImg : preview.modal.fallbackImg"
+              ksSize [sizeConfig]="{width: previewConfig?.size ? previewConfig?.size?.width! : defaultPreviewSize.width,
+                                    height: previewConfig?.size ? previewConfig?.size?.height! : defaultPreviewSize.height}"
+              [attr.aria-label]="preview.modal.ariaLabel ? preview.modal.ariaLabel : ''"
+              [title]="(preview.modal.title || preview.modal.title === '') ? preview.modal.title : ''"
+              alt="{{preview.modal.alt ? preview.modal.alt : ''}}"
+              [tabIndex]="0" role="img"
+          />
+        </ng-template>
       </div>
 
     </ng-container>

--- a/projects/ks89/angular-modal-gallery/src/lib/components/previews/previews.scss
+++ b/projects/ks89/angular-modal-gallery/src/lib/components/previews/previews.scss
@@ -108,27 +108,28 @@ $nav-side-margin: 10px;
     justify-content: center;
     margin-bottom: $container-margin-bottom;
 
-    > .preview-image {
-      cursor: pointer;
+    .preview-container {
       margin-left: $preview-image-side-margin;
       margin-right: $preview-image-side-margin;
-      opacity: $preview-image-opacity;
-      height: $preview-image-height;
-      //animation: fadein-semi-visible08 $preview-image-fade-in-time;
-
-      &.active {
-        opacity: $preview-image-hover-opacity;
-        //animation: fadein-visible $preview-image-fade-in-time;
-      }
-
+      cursor: pointer;
       &.unclickable {
         cursor: not-allowed;
       }
+      .preview-image {
+        opacity: $preview-image-opacity;
+        height: $preview-image-height;
+        //animation: fadein-semi-visible08 $preview-image-fade-in-time;
 
-      &:hover {
-        opacity: $preview-image-active-opacity;
-        transition: all .5s ease;
-        transition-property: opacity;
+        &.active {
+          opacity: $preview-image-hover-opacity;
+          //animation: fadein-visible $preview-image-fade-in-time;
+        }
+
+        &:hover {
+          opacity: $preview-image-active-opacity;
+          transition: all .5s ease;
+          transition-property: opacity;
+        }
       }
     }
 

--- a/projects/ks89/angular-modal-gallery/src/lib/model/modal-gallery-config.interface.ts
+++ b/projects/ks89/angular-modal-gallery/src/lib/model/modal-gallery-config.interface.ts
@@ -22,6 +22,7 @@
  SOFTWARE.
  */
 
+import { TemplateRef } from '@angular/core';
 import { Image } from './image.class';
 import { ModalLibConfig } from './lib-config.interface';
 
@@ -30,4 +31,11 @@ export interface ModalGalleryConfig {
   images: Image[];
   currentImage: Image;
   libConfig?: ModalLibConfig;
+  /**
+   * Optional template reference for the rendering of previews.
+   * Template may access following context variables:
+   * - "preview": the `Image` object of the preview
+   * - "defaultTemplate": the template used by default to render the preview (in case the need is to augment it)
+   */
+  previewsTemplate?: TemplateRef<HTMLElement>;
 }

--- a/src/app/modal-gallery/modal-gallery.component.ts
+++ b/src/app/modal-gallery/modal-gallery.component.ts
@@ -22,6 +22,8 @@
  SOFTWARE.
  */
 
+import { TemplateRef } from '@angular/core';
+import { ViewChild } from '@angular/core';
 import { Component, OnDestroy } from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 
@@ -46,6 +48,12 @@ import * as libConfigs from './libconfigs';
   styleUrls: ['./modal-gallery.scss']
 })
 export class ModalGalleryExampleComponent implements OnDestroy {
+  /**
+   * A custom template to illustrate the customization of previews rendering.
+   */
+  @ViewChild('previewsTemplate')
+  previewsTemplate?: TemplateRef<HTMLElement>;
+
   imageIndex = 0;
   galleryId = 1;
   isPlaying = true;
@@ -508,11 +516,13 @@ export class ModalGalleryExampleComponent implements OnDestroy {
       return;
     }
     const imageToShow: Image = imagesArrayToUse[imageIndex];
+    const previewsTemplate = (id === 902 ? this.previewsTemplate : undefined);
     const dialogRef: ModalGalleryRef = this.modalGalleryService.open({
       id,
       images: imagesArrayToUse,
       currentImage: imageToShow,
-      libConfig
+      libConfig,
+      previewsTemplate,
     } as ModalGalleryConfig) as ModalGalleryRef;
   }
 

--- a/src/app/modal-gallery/modal-gallery.component.ts
+++ b/src/app/modal-gallery/modal-gallery.component.ts
@@ -516,13 +516,11 @@ export class ModalGalleryExampleComponent implements OnDestroy {
       return;
     }
     const imageToShow: Image = imagesArrayToUse[imageIndex];
-    const previewsTemplate = (id === 902 ? this.previewsTemplate : undefined);
     const dialogRef: ModalGalleryRef = this.modalGalleryService.open({
       id,
       images: imagesArrayToUse,
       currentImage: imageToShow,
       libConfig,
-      previewsTemplate,
     } as ModalGalleryConfig) as ModalGalleryRef;
   }
 
@@ -717,6 +715,25 @@ export class ModalGalleryExampleComponent implements OnDestroy {
 
   trackById(index: number, item: Image): number {
     return item.id;
+  }
+
+  openModalWithPreviewsTemplate(id: number, imagesArrayToUse: Image[], imageIndex: number, libConfig?: ModalLibConfig): void {
+    if(imagesArrayToUse.length === 0) {
+      console.error('Cannot open modal-gallery because images array cannot be empty');
+      return;
+    }
+    if(imageIndex > imagesArrayToUse.length - 1) {
+      console.error('Cannot open modal-gallery because imageIndex must be valid');
+      return;
+    }
+    const imageToShow: Image = imagesArrayToUse[imageIndex];
+    const dialogRef: ModalGalleryRef = this.modalGalleryService.open({
+      id,
+      images: imagesArrayToUse,
+      currentImage: imageToShow,
+      libConfig,
+      previewsTemplate: this.previewsTemplate,
+    } as ModalGalleryConfig) as ModalGalleryRef;
   }
 
   ngOnDestroy(): void {

--- a/src/app/modal-gallery/modal-gallery.html
+++ b/src/app/modal-gallery/modal-gallery.html
@@ -315,3 +315,16 @@
   <h3>F2 - (id=901) - Experimental demo - an array of Images with the same source file (different classes/ids and paths with appended '?imageIndex' to prevent caching issues)</h3>
   <button (click)="openModal(901, sameImages, 0)">Open modalgallery</button>
 </section>
+<section>
+  <h3>F3 - (id=902) - Experimental demo - 'previews' rendering customization (via Angular templates)</h3>
+  <ng-template #previewsTemplate let-preview="preview" let-defaultTemplate="defaultTemplate">
+    <div class="preview-block">
+      <div class="preview-description">{{preview?.modal?.description ?? '&nbsp;'}}</div>
+      <div class="preview-default">
+        <ng-container *ngTemplateOutlet="defaultTemplate"></ng-container>
+      </div>
+    </div>
+  </ng-template>
+  <button (click)="openModal(902, images, imageIndex)">Open modalgallery</button>
+</section>
+

--- a/src/app/modal-gallery/modal-gallery.html
+++ b/src/app/modal-gallery/modal-gallery.html
@@ -325,6 +325,6 @@
       </div>
     </div>
   </ng-template>
-  <button (click)="openModal(902, images, imageIndex)">Open modalgallery</button>
+  <button (click)="openModalWithPreviewsTemplate(902, images, imageIndex)">Open modalgallery</button>
 </section>
 

--- a/src/app/modal-gallery/modal-gallery.scss
+++ b/src/app/modal-gallery/modal-gallery.scss
@@ -163,3 +163,15 @@ button {
 .title {
   margin-top: 40px;
 }
+
+.preview-block {
+  margin-right: 10px;
+}
+.preview-description {
+  color: #fff;
+  margin-bottom: 3px;
+}
+.preview-description,
+.preview-default {
+  text-align: center;
+}


### PR DESCRIPTION
(fix #253)
Hi there !
So this is another PR, which changes are already merged with my previous [PR](https://github.com/Ks89/angular-modal-gallery/pull/254). If you accept the 1st PR before this one and encounter merge problems, I'll make another PR with only these changes.

This is quite an important PR about previews. Please rest assured that I've worked on it and tested it quite thoroughly.
Each fixes is accompanied with corresponding tests, which fails on versions before the PR and are green with the PR.

This PR adresses different small quirks:

1. clicking the right image arrow always shifts the displayed previews, even in cases where it shouldn't, for instance for nbPreviews>=3 and current=0
That's what causes the flickering. The previews are then re-adjusted when 'images' are detected as changed by ngOnChanges; this was making the bug subtle and difficult to see/catch.

2. the number of previews oscillate between n (number of requested previews) and n-1/n+1, for example when n=4 or n=5

3. when opening the modal and navigating to the last preview by **clicking** on the right preview arrow, it's impossible to then click on the left preview arrow: isPreventSliding() prevents it

4. in infinite sliding, the left and right preview arrows should be always visible (like the left and right image arrows), except if nbPreviews < images.length
This is not a clear specification of your tool, but I've imagined it would be consistent.

I'll annotate the .spec file in the PR, so you can check which test addresses which point.
I'll also annotate the code in the PR, so you can understand the reason I had to refactor.

