### PR TITLE
fix: prevent circular dependency

### DIFF
--- a/projects/ks89/angular-modal-gallery/src/lib/components/modal-gallery/attach-to-overlay.service.spec.ts
+++ b/projects/ks89/angular-modal-gallery/src/lib/components/modal-gallery/attach-to-overlay.service.spec.ts
@@ -1,0 +1,105 @@
+import { inject, TestBed, waitForAsync } from '@angular/core/testing';
+import { AttachToOverlayService } from './attach-to-overlay.service';
+import { ModalGalleryService } from './modal-gallery.service';
+import { OverlayModule, OverlayRef } from '@angular/cdk/overlay';
+import { Image } from '../../model/image.class';
+import { ModalGalleryRef } from './modal-gallery-ref';
+
+const IMAGES: Image[] = [
+  new Image(0, {
+    // modal
+    img: '../assets/images/gallery/img1.jpg',
+    extUrl: 'http://www.google.com'
+  }),
+  new Image(1, {
+    // modal
+    img: '../assets/images/gallery/img2.png',
+    description: 'Description 2'
+  }),
+  new Image(
+    2,
+    {
+      // modal
+      img: '../assets/images/gallery/img3.jpg',
+      description: 'Description 3',
+      extUrl: 'http://www.google.com'
+    },
+    {
+      // plain
+      img: '../assets/images/gallery/thumbs/img3.png',
+      title: 'custom title 2',
+      alt: 'custom alt 2',
+      ariaLabel: 'arial label 2'
+    }
+  ),
+  new Image(3, {
+    // modal
+    img: '../assets/images/gallery/img4.jpg',
+    description: 'Description 4',
+    extUrl: 'http://www.google.com'
+  }),
+  new Image(
+    4,
+    {
+      // modal
+      img: '../assets/images/gallery/img5.jpg'
+    },
+    {
+      // plain
+      img: '../assets/images/gallery/thumbs/img5.jpg'
+    }
+  )
+];
+
+describe('AttachToOverlayService', () => {
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [OverlayModule],
+      providers: [
+        AttachToOverlayService,
+        {
+          provide: ModalGalleryService,
+          useClass: ModalGalleryService
+        }
+      ]
+    });
+  }));
+
+  it('should instantiate service when inject service', inject([AttachToOverlayService], (service: AttachToOverlayService) => {
+    expect(service instanceof AttachToOverlayService).toEqual(true);
+  }));
+
+  describe('#attachToOverlay()', () => {
+    describe('---YES---', () => {
+      it('should call the attach method on the given overlayRef', inject([ModalGalleryService], (modalGalleryService: ModalGalleryService) => {
+        const ID: number = 1;
+        const config = {
+          id: ID,
+          images: IMAGES,
+          currentImage: IMAGES[0]
+        };
+        const ref: ModalGalleryRef | undefined = modalGalleryService.open({
+          id: ID,
+          images: IMAGES,
+          currentImage: IMAGES[0]
+        });
+        expect(ref).toBeDefined();
+        expect(ref instanceof ModalGalleryRef).toBeTrue();
+        let attachCalled = false;
+        const mockOverlayRef = {
+          attach: () => {
+            attachCalled = true;
+          }
+        };
+
+        modalGalleryService.triggerAttachToOverlay.emit({
+          config,
+          dialogRef: ref as ModalGalleryRef,
+          overlayRef: mockOverlayRef as unknown as OverlayRef
+        });
+
+        expect(attachCalled).toBeTrue();
+      }));
+    });
+  });
+});

--- a/projects/ks89/angular-modal-gallery/src/lib/components/modal-gallery/attach-to-overlay.service.ts
+++ b/projects/ks89/angular-modal-gallery/src/lib/components/modal-gallery/attach-to-overlay.service.ts
@@ -1,0 +1,36 @@
+import { Injectable, Injector } from '@angular/core';
+import { ModalGalleryRef } from './modal-gallery-ref';
+import { ModalGalleryComponent } from './modal-gallery.component';
+import { DIALOG_DATA } from './modal-gallery.tokens';
+import { ComponentPortal } from '@angular/cdk/portal';
+import { AttachToOverlayPayload, ModalGalleryService } from './modal-gallery.service';
+
+@Injectable({ providedIn: 'root' })
+export class AttachToOverlayService {
+  constructor(private injector: Injector, private modalGalleryService: ModalGalleryService) {}
+
+  /**
+   * To be called by a provider with the APP_INITIALIZER token.
+   */
+  public initialize(): void {
+    this.modalGalleryService.triggerAttachToOverlay.subscribe(payload => this.attachToOverlay(payload));
+  }
+
+  /**
+   * Private method to attach ModalGalleryComponent to the overlay.
+   * @param payload {@link AttachToOverlayPayload} with all necessary information
+   * @private
+   */
+  private attachToOverlay(payload: AttachToOverlayPayload): void {
+    const injector: Injector = Injector.create({
+      parent: this.injector,
+      providers: [
+        { provide: ModalGalleryRef, useValue: payload.dialogRef },
+        { provide: DIALOG_DATA, useValue: payload.config }
+      ]
+    });
+
+    const containerPortal = new ComponentPortal(ModalGalleryComponent, null, injector);
+    payload.overlayRef.attach(containerPortal);
+  }
+}

--- a/projects/ks89/angular-modal-gallery/src/lib/components/modal-gallery/modal-gallery.service.spec.ts
+++ b/projects/ks89/angular-modal-gallery/src/lib/components/modal-gallery/modal-gallery.service.spec.ts
@@ -142,6 +142,25 @@ describe('ModalGalleryService', () => {
           expect(ref instanceof ModalGalleryRef).toBeTrue();
         })
       );
+
+      it('should trigger attachment of the component to the overlay', inject([ModalGalleryService], (service: ModalGalleryService) => {
+        const ID: number = 1;
+        const config = {
+          id: ID,
+          images: IMAGES,
+          currentImage: IMAGES[0]
+        };
+        let hasEmitted = false;
+
+        service.triggerAttachToOverlay.subscribe(payload => {
+          expect(payload.config).toEqual(config);
+          hasEmitted = true;
+        });
+
+        service.open(config);
+
+        expect(hasEmitted).toBeTrue();
+      }));
     });
   });
 

--- a/projects/ks89/angular-modal-gallery/src/lib/modal-gallery.module.ts
+++ b/projects/ks89/angular-modal-gallery/src/lib/modal-gallery.module.ts
@@ -22,13 +22,14 @@
  SOFTWARE.
  */
 
-import { NgModule } from '@angular/core';
+import { APP_INITIALIZER, NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { OverlayModule } from '@angular/cdk/overlay';
 
 import { COMPONENTS, CarouselComponent } from './components/components';
 import { PlainGalleryComponent } from './components/plain-gallery/plain-gallery.component';
 import { DIRECTIVES } from './directives/directives';
+import { AttachToOverlayService } from './components/modal-gallery/attach-to-overlay.service';
 
 /**
  * Module to import it in the root module of your application.
@@ -36,6 +37,16 @@ import { DIRECTIVES } from './directives/directives';
 @NgModule({
   imports: [CommonModule, OverlayModule],
   declarations: [COMPONENTS, DIRECTIVES],
+  providers: [
+    {
+      provide: APP_INITIALIZER,
+      multi: true,
+      deps: [AttachToOverlayService],
+      useFactory: (service: AttachToOverlayService): (() => void) => {
+        return () => service.initialize();
+      }
+    }
+  ],
   exports: [PlainGalleryComponent, CarouselComponent]
 })
 export class GalleryModule {}


### PR DESCRIPTION
Closes #261 
This would be the proposed solution as discussed in the issue.

I tried to be consistent regarding test structure and so on, but I'm not sure if I was successful everywhere.
I tried creating a service for handling everything overlay-related, but due to the strong connections between the `overlayRef` and the `dialogRef` that did not work to well so for now I only extracted the "attach to overlay" functionality, i.e. the part that was responsible for the circular dependency in the first place.

The `open` method is still part of the `ModalGalleryService`, this includes no breaking changes.